### PR TITLE
Use noninterference function in benchmark.

### DIFF
--- a/configfs/faketsm/fakereport_test.go
+++ b/configfs/faketsm/fakereport_test.go
@@ -175,5 +175,5 @@ func BenchmarkReportGenerationInterference(b *testing.B) {
 }
 
 func BenchmarkReportGenerationNoninterference(b *testing.B) {
-	nonceAnonceB(b, 20, b.N)
+	noninterferenceByDesign(b, 20, b.N)
 }


### PR DESCRIPTION
The fakereport_test defines some unused functions that are meant to test concurrent goroutines do not interfere with one another. There was a copy/base error that the noninterference test used nonceAnonceB instead of runnoninterferenceByDesign.