### PR TITLE
Add rtmr extend package.

### DIFF
--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -1,0 +1,197 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fakertmr defines a configfsi.Client for faking TSM behavior.
+// The current implementation only supports TDX.
+package fakertmr
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/sha512"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strconv"
+	"syscall"
+
+	"github.com/google/go-configfs-tsm/configfs/configfsi"
+)
+
+const (
+	tsmRtmrDigest = "digest"
+	tsmPathIndex  = "index"
+	tsmPathTcgMap = "tcg_map"
+)
+
+// rtmrValue represents the value of a rtmr index.
+type rtmrValue struct {
+	RtmrIndex int
+	Digest    []byte
+	TcgMap    []byte
+}
+
+// rtmrEntry represents a rtmr entry in the configfs.
+type rtmrEntry struct {
+	RtmrIndex   int
+	Initialized bool
+	// RtmrMaps is a map of rtmr index to rtmr value.
+	// All RrmrMaps must be initialized with the value from RtmrSubsystem.
+	RtmrMaps map[int]*rtmrValue
+}
+
+// RtmrSubsystem represents a fake configfs-tsm rtmr subsystem.
+type RtmrSubsystem struct {
+	// WriteAttr called on any WriteFile to an attribute.
+	WriteInAttr func(e *rtmrEntry, attr string, contents []byte) error
+	// ReadAttr is called on any non-InAddr key.
+	ReadAttr func(e *rtmrEntry, attr string) ([]byte, error)
+	// Random is the source of randomness to use for MkdirTemp
+	Random io.Reader
+	// RtmrMaps is a map of rtmr index to rtmr value.
+	RtmrMaps map[int]*rtmrValue
+	// Entries is a map of rtmr entry name to rtmr entry.
+	Entries map[string]*rtmrEntry
+}
+
+// RemoveAll implements configfsi.Client.
+func (r *RtmrSubsystem) RemoveAll(path string) error {
+	return errors.New("rtmr subsystem does not support RemoveAll")
+}
+
+func readTdx(entry *rtmrEntry, attr string) ([]byte, error) {
+	if !entry.Initialized {
+		return nil, os.ErrNotExist
+	}
+	switch attr {
+	case tsmRtmrDigest:
+		return entry.RtmrMaps[entry.RtmrIndex].Digest, nil
+	case tsmPathIndex:
+		return []byte(strconv.Itoa(entry.RtmrIndex)), nil
+	case tsmPathTcgMap:
+		return entry.RtmrMaps[entry.RtmrIndex].TcgMap, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func writeTdx(entry *rtmrEntry, attr string, content []byte) error {
+	switch attr {
+	case tsmRtmrDigest:
+		if len(content) != crypto.SHA384.Size() {
+			return syscall.EINVAL
+		}
+		if !entry.Initialized {
+			return os.ErrNotExist
+		}
+		// According to the TDX module spec, userspace can only extend rtmr2 or rtmr3
+		if entry.RtmrIndex != 2 && entry.RtmrIndex != 3 {
+			return os.ErrPermission
+		}
+		oldDigest := entry.RtmrMaps[entry.RtmrIndex].Digest
+		newDigest := sha512.Sum384(append(oldDigest[:], content...))
+		entry.RtmrMaps[entry.RtmrIndex].Digest = newDigest[:]
+	case tsmPathIndex:
+		index, e := strconv.Atoi(string(content))
+		if e != nil {
+			return fmt.Errorf("WriteTdx: %v", e)
+		}
+		entry.RtmrIndex = index
+		entry.Initialized = true
+		value := entry.RtmrMaps[index]
+		var rtmrPcrMaps = map[int]string{
+			0: "1,7\n",
+			1: "2-6\n",
+			2: "8-15\n",
+			3: "\n",
+		}
+		if value == nil {
+			value = &rtmrValue{
+				RtmrIndex: index,
+				Digest:    make([]byte, crypto.SHA384.Size()),
+				TcgMap:    []byte(rtmrPcrMaps[index]),
+			}
+			entry.RtmrMaps[index] = value
+		}
+	default:
+		return fmt.Errorf("WriteTdx: unknown attribute %q", attr)
+	}
+	return nil
+}
+
+// MkdirTemp creates a new temporary directory in the rtmr subsystem.
+func (r *RtmrSubsystem) MkdirTemp(dir, pattern string) (string, error) {
+	p, err := configfsi.ParseTsmPath(dir)
+	if err != nil {
+		return "", fmt.Errorf("MkdirTemp: Error %v", err)
+	}
+	if p.Entry != "" {
+		return "", fmt.Errorf("MkdirTemp: rtmr entry %q cannot have subdirectories", dir)
+	}
+
+	if r.Entries == nil {
+		r.Entries = make(map[string]*rtmrEntry)
+	}
+	name := configfsi.TempName(r.Random, pattern)
+	if _, ok := r.Entries[name]; ok {
+		return "", os.ErrExist
+	}
+	r.Entries[name] = &rtmrEntry{Initialized: false, RtmrMaps: r.RtmrMaps}
+	return path.Join(dir, name), nil
+}
+
+// ReadFile reads the contents of a file in the rtmr subsystem.
+func (r *RtmrSubsystem) ReadFile(name string) ([]byte, error) {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return nil, fmt.Errorf("ReadFile: Error %v", err)
+	}
+	if r.Entries == nil {
+		return nil, os.ErrNotExist
+	}
+	entry, ok := r.Entries[p.Entry]
+	if !ok || entry == nil {
+		return nil, os.ErrNotExist
+	}
+	return r.ReadAttr(entry, p.Attribute)
+}
+
+// WriteFile writes the contents to a file in the rtmr subsystem.
+func (r *RtmrSubsystem) WriteFile(name string, content []byte) error {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return fmt.Errorf("WriteFile: %v", err)
+	}
+	if p.Attribute == "" {
+		return fmt.Errorf("WriteFile: no attribute specified to %q", name)
+	}
+	entry, ok := r.Entries[p.Entry]
+	if !ok || entry == nil {
+		return os.ErrNotExist
+	}
+	return r.WriteInAttr(entry, p.Attribute, content)
+}
+
+// CreateRtmrSubsystem creates a new rtmr subsystem.
+// The current subsystem only supports TDX.
+func CreateRtmrSubsystem() *RtmrSubsystem {
+	return &RtmrSubsystem{
+		Random:      rand.Reader,
+		WriteInAttr: writeTdx,
+		ReadAttr:    readTdx,
+		RtmrMaps:    make(map[int]*rtmrValue),
+		Entries:     make(map[string]*rtmrEntry),
+	}
+}

--- a/rtmr/rtmr.go
+++ b/rtmr/rtmr.go
@@ -1,0 +1,210 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rtmr provides an API to the configfs/tsm/rtmr subsystem for
+// extending runtime measurements to RTMR registers.
+package rtmr
+
+import (
+	"crypto"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/google/go-configfs-tsm/configfs/configfsi"
+)
+
+const (
+	rtmrSubsystem = "rtmrs"
+	tsmRtmrPrefix = configfsi.TsmPrefix + "/" + rtmrSubsystem
+	// The digest of the rtmr register.
+	tsmRtmrDigest = "digest"
+	// A Runtime Measurement Register (RTMR) hardware index.
+	tsmPathIndex = "index"
+	// A representation of the architecturally defined mapping between this RTMR and one or more TCG TPM PCRs
+	tsmPathTcgMap = "tcg_map"
+)
+
+// Extend is a struct that represents a rtmr entry in the configfs.
+type Extend struct {
+	RtmrIndex int
+	entry     *configfsi.TsmPath
+	client    configfsi.Client
+}
+
+// Response is a struct that represents the response of reading a rtmr entry in the configfs.
+type Response struct {
+	RtmrIndex int
+	digest    []byte
+	tcgMap    []byte
+}
+
+func (r *Extend) attribute(subtree string) string {
+	a := *r.entry
+	a.Attribute = subtree
+	return a.String()
+}
+
+// extendDigest extends the measurement to the rtmr with the given hash.
+func (r *Extend) extendDigest(hash []byte) error {
+	if err := r.client.WriteFile(r.attribute(tsmRtmrDigest), hash); err != nil {
+		return fmt.Errorf("could not write digest to rmtr%d: %v", r.RtmrIndex, err)
+	}
+	return nil
+}
+
+// getDigest returns the digest of the rtmr.
+func (r *Extend) getDigest() ([]byte, error) {
+	return r.client.ReadFile(r.attribute(tsmRtmrDigest))
+}
+
+// getTcgMap returns the tcg map of the rtmr.
+func (r *Extend) getTcgMap() ([]byte, error) {
+	return r.client.ReadFile(r.attribute(tsmPathTcgMap))
+}
+
+// validateIndex checks if the rtmr index is valid.
+func (r *Extend) validateIndex() error {
+	indexBytes, err := r.client.ReadFile(r.attribute(tsmPathIndex))
+	if err != nil {
+		return fmt.Errorf("could not read index %s: %v", r.attribute(tsmPathIndex), err)
+	}
+	index, err := configfsi.Kstrtouint(indexBytes, 10, 64)
+	if err != nil {
+		return fmt.Errorf("could not convert index %s to integer: %v", indexBytes, err)
+	}
+	if (int)(index) != r.RtmrIndex {
+		return fmt.Errorf("rtmr index %d does not match the expected index %d", index, r.RtmrIndex)
+	}
+	return nil
+}
+
+// setRtmrIndex sets a configfs rtmr entry to the given index.
+// It reports an error if the index cannot be written.
+func (r *Extend) setRtmrIndex() error {
+	indexBytes := []byte(strconv.Itoa(r.RtmrIndex)) // Convert index to []byte
+	indexPath := r.attribute(tsmPathIndex)
+	if err := r.client.WriteFile(indexPath, indexBytes); err != nil {
+		return fmt.Errorf("could not write index %s: %v", indexPath, err)
+	}
+	return nil
+}
+
+// searchRtmrInterface searches for an rtmr entry in the configfs.
+func searchRtmrInterface(client configfsi.Client, index int) (*Extend, error) {
+	root := tsmRtmrPrefix
+	out := &Extend{}
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			p, err := configfsi.ParseTsmPath(path)
+			if err != nil {
+				return err
+			}
+			r := &Extend{
+				RtmrIndex: index,
+				entry:     &configfsi.TsmPath{Subsystem: rtmrSubsystem, Entry: p.Entry},
+				client:    client,
+			}
+			if r.validateIndex() == nil {
+				out = r
+				return nil
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := out.validateIndex(); err != nil {
+		return out, nil
+	} else {
+		return nil, err
+	}
+
+}
+
+// createRtmrInterface creates a new rtmr entry in the configfs.
+func createRtmrInterface(client configfsi.Client, index int) (*Extend, error) {
+	entryPath, err := client.MkdirTemp(tsmRtmrPrefix, fmt.Sprintf("rtmr%d-", index))
+	if err != nil {
+		return nil, fmt.Errorf("could not create rtmr entry in configfs: %v", err)
+	}
+	p, _ := configfsi.ParseTsmPath(entryPath)
+
+	r := &Extend{
+		RtmrIndex: index,
+		entry:     &configfsi.TsmPath{Subsystem: rtmrSubsystem, Entry: p.Entry},
+		client:    client,
+	}
+
+	if err := r.setRtmrIndex(); err != nil {
+		return nil, fmt.Errorf("could not set rtmr index %d: %v", index, err)
+	}
+	return r, nil
+}
+
+// getRtmrInterface returns the rtmr entry in the configfs.
+func getRtmrInterface(client configfsi.Client, index int) (*Extend, error) {
+	// The configfs-tsm interface only allows one rtmr entry for a given index.
+	// If the rtmr entry already exists, we should extend the digest to it.
+	r, err := searchRtmrInterface(client, index)
+	if err != nil {
+		r, err = createRtmrInterface(client, index)
+	}
+	return r, err
+}
+
+// ExtendDigest extends the measurement to the rtmr with the given digest.
+func ExtendDigest(client configfsi.Client, rtmr int, digest []byte) error {
+	if len(digest) != crypto.SHA384.Size() {
+		return fmt.Errorf("the length of the digest must be %d bytes, the input is %d bytes", crypto.SHA384.Size(), len(digest))
+	}
+	if rtmr < 0 {
+		return fmt.Errorf("invalid rtmr index %d. Index can only be a non-negative number", rtmr)
+	}
+	r, err := getRtmrInterface(client, rtmr)
+	if err != nil {
+		return err
+	}
+	return r.extendDigest(digest)
+}
+
+// GetDigest returns the digest and the tcg map of a given rtmr index.
+func GetDigest(client configfsi.Client, rtmr int) (*Response, error) {
+	if rtmr < 0 {
+		return nil, fmt.Errorf("invalid rtmr index %d. Index can only be a non-negative number", rtmr)
+	}
+	r, err := getRtmrInterface(client, rtmr)
+	if err != nil {
+		return nil, err
+	}
+	digest, err := r.getDigest()
+	if err != nil {
+		return nil, err
+	}
+	tcgmap, err := r.getTcgMap()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		RtmrIndex: rtmr,
+		digest:    digest,
+		tcgMap:    tcgmap,
+	}, nil
+}

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -1,0 +1,118 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rtmr
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-configfs-tsm/configfs/fakertmr"
+)
+
+func TestExtendDigestErr(t *testing.T) {
+	var sha384Hash [48]byte
+
+	tcsErr := []struct {
+		rtmr    int
+		digest  []byte
+		wantErr string
+	}{
+		{rtmr: 1, digest: sha384Hash[:], wantErr: "could not write digest to rmtr1"},
+		{rtmr: 3, digest: []byte("aaaaaaaa"), wantErr: "the length of the digest must be 48 bytes"},
+	}
+	client := fakertmr.CreateRtmrSubsystem()
+	for _, tc := range tcsErr {
+		err := ExtendDigest(client, tc.rtmr, tc.digest)
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("ExtendtoRtmrClient(%d, %q) failed: %v, want %q", tc.rtmr, tc.digest, err, tc.wantErr)
+		}
+	}
+}
+
+func TestExtendDigestRtmrOk(t *testing.T) {
+	var sha384Hash [48]byte
+
+	tcsOk := []struct {
+		rtmr   int
+		digest []byte
+	}{
+		{rtmr: 2, digest: sha384Hash[:]},
+		{rtmr: 3, digest: sha384Hash[:]},
+		{rtmr: 3, digest: sha384Hash[:]},
+	}
+	client := fakertmr.CreateRtmrSubsystem()
+	for _, tc := range tcsOk {
+		err := ExtendDigest(client, tc.rtmr, tc.digest)
+		if err != nil {
+			t.Fatalf("ExtendtoRtmrClient (%d, %q) failed: %v", tc.rtmr, tc.digest, err)
+		}
+	}
+}
+
+func TestGetDigest(t *testing.T) {
+	var sha384Hash [48]byte
+	tcsOk := []struct {
+		rtmr   int
+		digest []byte
+		tcgMap []byte
+	}{
+		{rtmr: 0, digest: sha384Hash[:], tcgMap: []byte("1,7\n")},
+		{rtmr: 1, digest: sha384Hash[:], tcgMap: []byte("2-6\n")},
+		{rtmr: 2, digest: sha384Hash[:], tcgMap: []byte("8-15\n")},
+		{rtmr: 3, digest: sha384Hash[:], tcgMap: []byte("\n")},
+	}
+	client := fakertmr.CreateRtmrSubsystem()
+	for _, tc := range tcsOk {
+		r, err := GetDigest(client, tc.rtmr)
+		if err != nil {
+			t.Fatalf("GetDigestRtmr(%d) failed: %v", tc.rtmr, err)
+		}
+		if r.RtmrIndex != tc.rtmr {
+			t.Fatalf("GetDigestRtmr(%d) failed: got %d, want %d", tc.rtmr, r.RtmrIndex, tc.rtmr)
+		}
+		if !bytes.Equal(r.digest, tc.digest) {
+			t.Fatalf("GetDigestRtmr(%d) failed: got %q, want %q", tc.rtmr, r.digest, tc.digest)
+		}
+		if !bytes.Equal(r.tcgMap, tc.tcgMap) {
+			t.Fatalf("GetDigestRtmr(%d) failed: got %q, want %q", tc.rtmr, r.tcgMap, tc.tcgMap)
+		}
+	}
+}
+
+func TestGetRtmrDigestAndExtendDigest(t *testing.T) {
+	var sha384Hash [48]byte
+	sha384Hash[0] = 0x01
+	client := fakertmr.CreateRtmrSubsystem()
+	rtmrIndex := 3
+	// GetDigest
+	digest1, err := GetDigest(client, rtmrIndex)
+	if err != nil {
+		t.Fatalf("GetDigest(%d) failed: %v", rtmrIndex, err)
+	}
+	// ExtendDigest
+	err = ExtendDigest(client, rtmrIndex, sha384Hash[:])
+	if err != nil {
+		t.Fatalf("ExtendDigest(%d) failed: %v", rtmrIndex, err)
+	}
+	// GetDigest
+	digest2, err := GetDigest(client, rtmrIndex)
+	if err != nil {
+		t.Fatalf("GetDigest(%d) failed: %v", rtmrIndex, err)
+	}
+	if bytes.Equal(digest1.digest, digest2.digest) {
+		t.Fatalf("rtmr%q does not change after an extend %q", rtmrIndex, digest2.digest)
+	}
+}

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -32,6 +32,7 @@ func TestExtendDigestErr(t *testing.T) {
 	}{
 		{rtmr: 1, digest: sha384Hash[:], wantErr: "could not write digest to rmtr1"},
 		{rtmr: 3, digest: []byte("aaaaaaaa"), wantErr: "the length of the digest must be 48 bytes"},
+		{rtmr: -1, digest: sha384Hash[:], wantErr: "invalid rtmr index -1. Index can only be a non-negative number"},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
 	for _, tc := range tcsErr {
@@ -62,7 +63,23 @@ func TestExtendDigestRtmrOk(t *testing.T) {
 	}
 }
 
-func TestGetDigest(t *testing.T) {
+func TestGetDigestErr(t *testing.T) {
+	tcsErr := []struct {
+		rtmr    int
+		wantErr string
+	}{
+		{rtmr: -1, wantErr: "invalid rtmr index -1. Index can only be a non-negative number"},
+	}
+	client := fakertmr.CreateRtmrSubsystem()
+	for _, tc := range tcsErr {
+		_, err := GetDigest(client, tc.rtmr)
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("GetDigestRtmr(%d) failed: %v, want %q", tc.rtmr, err, tc.wantErr)
+		}
+	}
+}
+
+func TestGetDigestOk(t *testing.T) {
 	var sha384Hash [48]byte
 	tcsOk := []struct {
 		rtmr   int


### PR DESCRIPTION
Some confidential computing architecture (Intel TDX, ARM-CCA, RISC-V CoVE) provide the TVM (confidential computing guest) with a set of runtime measurement registers (RTMR).

This package adds the user space RTMR support for TDX guest. User space applications can extend its measurement into rtmr2 and rtmr3

This package is based on the kernel patches from
https://github.com/intel/tdx/commits/guest-rtmr

The package only supports TDX.