### PR TITLE
Fix a nil dereference buf in validateIndex

### DIFF
--- a/configfs/configfsi/configfsi.go
+++ b/configfs/configfsi/configfsi.go
@@ -15,6 +15,10 @@
 // Package configfsi defines an interface for interaction with the TSM configfs subsystem.
 package configfsi
 
+import (
+	"os"
+)
+
 // Client abstracts the filesystem operations for interacting with configfs files.
 type Client interface {
 	// MkdirTemp creates a new temporary directory in the directory dir and returns the pathname
@@ -22,6 +26,8 @@ type Client interface {
 	MkdirTemp(dir, pattern string) (string, error)
 	// ReadFile reads the named file and returns the contents.
 	ReadFile(name string) ([]byte, error)
+	// ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
+	ReadDir(dirname string) ([]os.DirEntry, error)
 	// WriteFile writes data to the named file, creating it if necessary. The permissions
 	// are implementation-defined.
 	WriteFile(name string, contents []byte) error

--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -67,7 +66,7 @@ type RtmrSubsystem struct {
 	RtmrMaps map[int]*rtmrValue
 	// Entries is a map of rtmr entry name to rtmr entry.
 	Entries map[string]*rtmrEntry
-	// If set true, ReadDir will returns a list of directory entries.
+	// If set true, ReadDir will return a list of directory entries.
 	SetEntries bool
 }
 
@@ -149,11 +148,11 @@ func (r *RtmrSubsystem) ReadDir(dirname string) ([]os.DirEntry, error) {
 	for _, index := range rtmr {
 		entryPath, err := os.MkdirTemp(rtmrDirs, fmt.Sprintf("rtmr%d-", index))
 		if err != nil {
-			log.Fatalf("MkdirTemp: %v", err)
+			return nil, fmt.Errorf("ReadDir: %v", err)
 		}
 		index_file := filepath.Join(entryPath, tsmPathIndex)
 		if err := os.WriteFile(index_file, []byte(fmt.Sprintf("%v", index)), 0666); err != nil {
-			log.Fatalf("WriteFile: %v", err)
+			return nil, fmt.Errorf("ReadDir: %v", err)
 		}
 	}
 	return os.ReadDir(rtmrDirs)

--- a/configfs/linuxtsm/linuxtsm.go
+++ b/configfs/linuxtsm/linuxtsm.go
@@ -48,6 +48,12 @@ func (*client) RemoveAll(path string) error {
 	return os.Remove(path)
 }
 
+// ReadDir reads the directory named by dirname and returns a list of directory
+// entries sorted by filename.
+func (*client) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return os.ReadDir(dirname)
+}
+
 // MakeClient returns a "real" client for using configfs for TSM use.
 func MakeClient() (configfsi.Client, error) {
 	// Linux client expects just the "report" subsystem for now.

--- a/rtmr/rtmr.go
+++ b/rtmr/rtmr.go
@@ -106,7 +106,6 @@ func (r *Extend) setRtmrIndex() error {
 // searchRtmrInterface searches for an rtmr entry in the configfs.
 func searchRtmrInterface(client configfsi.Client, index int) *Extend {
 	root := tsmRtmrPrefix
-	var out *Extend
 	entries, err := client.ReadDir(root)
 	if err != nil {
 		return nil
@@ -119,12 +118,11 @@ func searchRtmrInterface(client configfsi.Client, index int) *Extend {
 				client:    client,
 			}
 			if r.validateIndex() {
-				out = r
-				break
+				return r
 			}
 		}
 	}
-	return out
+	return nil
 }
 
 // createRtmrInterface creates a new rtmr entry in the configfs.

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -63,6 +63,26 @@ func TestExtendDigestRtmrOk(t *testing.T) {
 	}
 }
 
+func TestExtendDigestRtmrWithExistingEntriesOk(t *testing.T) {
+	var sha384Hash [48]byte
+
+	tcsOk := []struct {
+		rtmr   int
+		digest []byte
+	}{
+		{rtmr: 2, digest: sha384Hash[:]},
+		{rtmr: 3, digest: sha384Hash[:]},
+		{rtmr: 3, digest: sha384Hash[:]},
+	}
+	client := fakertmr.CreateRtmrSubsystemWithEntries()
+	for _, tc := range tcsOk {
+		err := ExtendDigest(client, tc.rtmr, tc.digest)
+		if err != nil {
+			t.Fatalf("ExtendtoRtmrClient (%d, %q) failed: %v", tc.rtmr, tc.digest, err)
+		}
+	}
+}
+
 func TestGetDigestErr(t *testing.T) {
 	tcsErr := []struct {
 		rtmr    int


### PR DESCRIPTION
When no entry is found, out.entry may not have a value.
