### PR TITLE
Rewrite the fake rtmr subsystem.

### DIFF
--- a/configfs/configfsi/configfsi.go
+++ b/configfs/configfsi/configfsi.go
@@ -15,6 +15,10 @@
 // Package configfsi defines an interface for interaction with the TSM configfs subsystem.
 package configfsi
 
+import (
+	"os"
+)
+
 // Client abstracts the filesystem operations for interacting with configfs files.
 type Client interface {
 	// MkdirTemp creates a new temporary directory in the directory dir and returns the pathname
@@ -22,6 +26,8 @@ type Client interface {
 	MkdirTemp(dir, pattern string) (string, error)
 	// ReadFile reads the named file and returns the contents.
 	ReadFile(name string) ([]byte, error)
+	// ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
+	ReadDir(dirname string) ([]os.DirEntry, error)
 	// WriteFile writes data to the named file, creating it if necessary. The permissions
 	// are implementation-defined.
 	WriteFile(name string, contents []byte) error

--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"syscall"
 
@@ -37,34 +38,17 @@ const (
 	tsmPathTcgMap = "tcg_map"
 )
 
-// rtmrValue represents the value of a rtmr index.
-type rtmrValue struct {
-	rtmrIndex int
-	digest    []byte
-	tcgMap    []byte
-}
-
-// rtmrEntry represents a rtmr entry in the configfs.
-type rtmrEntry struct {
-	rtmrIndex   int
-	initialized bool
-	// rtmrMaps is a map of rtmr index to rtmr value.
-	// All RrmrMaps must be initialized with the value from RtmrSubsystem.
-	rtmrMaps map[int]*rtmrValue
-}
-
 // RtmrSubsystem represents a fake configfs-tsm rtmr subsystem.
 type RtmrSubsystem struct {
 	// WriteAttr called on any WriteFile to an attribute.
-	WriteAttr func(e *rtmrEntry, attr string, contents []byte) error
+	WriteAttr func(dirname string, attr string, contents []byte) error
 	// ReadAttr is called on any non-InAddr key.
-	ReadAttr func(e *rtmrEntry, attr string) ([]byte, error)
+	ReadAttr func(dirname string, attr string) ([]byte, error)
 	// Random is the source of randomness to use for MkdirTemp
 	Random io.Reader
-	// RtmrMaps is a map of rtmr index to rtmr value.
-	RtmrMaps map[int]*rtmrValue
-	// Entries is a map of rtmr entry name to rtmr entry.
-	Entries map[string]*rtmrEntry
+	// We use a temp folder to store the rtmr entries.
+	// The path to the fake rtmr subsystem.
+	Path string
 }
 
 // RemoveAll implements configfsi.Client.
@@ -72,61 +56,85 @@ func (r *RtmrSubsystem) RemoveAll(path string) error {
 	return errors.New("rtmr subsystem does not support RemoveAll")
 }
 
-func readTdx(entry *rtmrEntry, attr string) ([]byte, error) {
-	if !entry.initialized {
-		return nil, os.ErrNotExist
-	}
-	switch attr {
-	case tsmRtmrDigest:
-		return entry.rtmrMaps[entry.rtmrIndex].digest, nil
-	case tsmPathIndex:
-		return []byte(strconv.Itoa(entry.rtmrIndex)), nil
-	case tsmPathTcgMap:
-		return entry.rtmrMaps[entry.rtmrIndex].tcgMap, nil
-	}
-	return nil, os.ErrNotExist
+func readTdx(entry string, attr string) ([]byte, error) {
+	return os.ReadFile(path.Join(entry, attr))
 }
 
-func writeTdx(entry *rtmrEntry, attr string, content []byte) error {
+func writeTdx(entry string, attr string, content []byte) error {
 	switch attr {
 	case tsmRtmrDigest:
+		// Check if the content is a valid SHA384 hash.
 		if len(content) != crypto.SHA384.Size() {
 			return syscall.EINVAL
 		}
-		if !entry.initialized {
-			return os.ErrNotExist
+		// Check if the entry is initialized.
+		content, err := os.ReadFile(filepath.Join(entry, tsmPathIndex))
+		if err != nil {
+			return err
 		}
-		// According to the TDX module spec, userspace can only extend rtmr2 or rtmr3
-		if entry.rtmrIndex != 2 && entry.rtmrIndex != 3 {
+		rtmrIndex, err := strconv.Atoi(string(content))
+		if err != nil {
+			return err
+		}
+		if rtmrIndex != 2 && rtmrIndex != 3 {
 			return os.ErrPermission
 		}
-		oldDigest := entry.rtmrMaps[entry.rtmrIndex].digest
+		oldDigest, err := os.ReadFile(filepath.Join(entry, tsmRtmrDigest))
+		if err != nil {
+			return err
+		}
 		newDigest := sha512.Sum384(append(oldDigest[:], content...))
-		entry.rtmrMaps[entry.rtmrIndex].digest = newDigest[:]
+		if err := os.WriteFile(filepath.Join(entry, tsmRtmrDigest), newDigest[:], 0666); err != nil {
+			return err
+		}
 	case tsmPathIndex:
-		index, e := strconv.Atoi(string(content))
+		rtmrIndex, e := strconv.Atoi(string(content))
 		if e != nil {
 			return fmt.Errorf("WriteTdx: %v", e)
 		}
-		entry.rtmrIndex = index
-		entry.initialized = true
-		value := entry.rtmrMaps[index]
+		if rtmrIndex < 0 || rtmrIndex > 3 {
+			return fmt.Errorf("WriteTdx: invalid rtmr index %d. Index can only be a non-negative number", rtmrIndex)
+		}
+		if err := os.WriteFile(filepath.Join(entry, tsmPathIndex), content, 0666); err != nil {
+			return err
+		}
 		var rtmrPcrMaps = map[int]string{
 			0: "1,7\n",
 			1: "2-6\n",
 			2: "8-15\n",
 			3: "\n",
 		}
-		if value == nil {
-			value = &rtmrValue{
-				rtmrIndex: index,
-				digest:    make([]byte, crypto.SHA384.Size()),
-				tcgMap:    []byte(rtmrPcrMaps[index]),
-			}
-			entry.rtmrMaps[index] = value
+		if err := os.WriteFile(filepath.Join(entry, tsmPathTcgMap), []byte(rtmrPcrMaps[rtmrIndex]), 0666); err != nil {
+			return err
 		}
+	case tsmPathTcgMap:
+		return os.ErrPermission
 	default:
 		return fmt.Errorf("WriteTdx: unknown attribute %q", attr)
+	}
+	return nil
+}
+
+// ReadDir reads the directory named by dirname
+// and returns a list of directory entries sorted by filename.
+func (r *RtmrSubsystem) ReadDir(dirname string) ([]os.DirEntry, error) {
+	p, err := configfsi.ParseTsmPath(dirname)
+	if err != nil {
+		return nil, fmt.Errorf("ReadDir: %v", err)
+	}
+	if p.Entry != "" {
+		return nil, fmt.Errorf("ReadDir: rtmr tsm %q cannot have subdirectories", dirname)
+	}
+	return os.ReadDir(r.Path)
+}
+
+func createEmptyFile(path string) error {
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -140,15 +148,29 @@ func (r *RtmrSubsystem) MkdirTemp(dir, pattern string) (string, error) {
 	if p.Entry != "" {
 		return "", fmt.Errorf("MkdirTemp: rtmr entry %q cannot have subdirectories", dir)
 	}
-
-	if r.Entries == nil {
-		r.Entries = make(map[string]*rtmrEntry)
+	if _, err := os.Stat(r.Path); os.IsNotExist(err) {
+		if err = os.Mkdir(r.Path, 0755); err != nil {
+			return "", fmt.Errorf("MkdirTemp: %v", err)
+		}
 	}
 	name := configfsi.TempName(r.Random, pattern)
-	if _, ok := r.Entries[name]; ok {
-		return "", os.ErrExist
+	fakeRtmrPath := path.Join(r.Path, name)
+	if err = os.Mkdir(fakeRtmrPath, 0755); err != nil {
+		return "", fmt.Errorf("MkdirTemp: %v", err)
 	}
-	r.Entries[name] = &rtmrEntry{initialized: false, rtmrMaps: r.RtmrMaps}
+	// Create empty index, digest and tcg_map files.
+	if err = createEmptyFile(filepath.Join(fakeRtmrPath, tsmPathIndex)); err != nil {
+		return "", fmt.Errorf("MkdirTemp: %v", err)
+	}
+
+	if err = createEmptyFile(filepath.Join(fakeRtmrPath, tsmRtmrDigest)); err != nil {
+		return "", fmt.Errorf("MkdirTemp: %v", err)
+	}
+
+	if err = createEmptyFile(filepath.Join(fakeRtmrPath, tsmPathTcgMap)); err != nil {
+		return "", fmt.Errorf("MkdirTemp: %v", err)
+	}
+
 	return path.Join(dir, name), nil
 }
 
@@ -158,14 +180,7 @@ func (r *RtmrSubsystem) ReadFile(name string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ReadFile: Error %v", err)
 	}
-	if r.Entries == nil {
-		return nil, os.ErrNotExist
-	}
-	entry, ok := r.Entries[p.Entry]
-	if !ok || entry == nil {
-		return nil, os.ErrNotExist
-	}
-	return r.ReadAttr(entry, p.Attribute)
+	return r.ReadAttr(path.Join(r.Path, p.Entry), p.Attribute)
 }
 
 // WriteFile writes the contents to a file in the rtmr subsystem.
@@ -177,11 +192,7 @@ func (r *RtmrSubsystem) WriteFile(name string, content []byte) error {
 	if p.Attribute == "" {
 		return fmt.Errorf("WriteFile: no attribute specified to %q", name)
 	}
-	entry, ok := r.Entries[p.Entry]
-	if !ok || entry == nil {
-		return os.ErrNotExist
-	}
-	return r.WriteAttr(entry, p.Attribute, content)
+	return r.WriteAttr(path.Join(r.Path, p.Entry), p.Attribute, content)
 }
 
 // CreateRtmrSubsystem creates a new rtmr subsystem.
@@ -191,7 +202,6 @@ func CreateRtmrSubsystem() *RtmrSubsystem {
 		Random:    rand.Reader,
 		WriteAttr: writeTdx,
 		ReadAttr:  readTdx,
-		RtmrMaps:  make(map[int]*rtmrValue),
-		Entries:   make(map[string]*rtmrEntry),
+		Path:      path.Join(os.TempDir(), "rtmr"),
 	}
 }

--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -148,10 +148,8 @@ func (r *RtmrSubsystem) MkdirTemp(dir, pattern string) (string, error) {
 	if p.Entry != "" {
 		return "", fmt.Errorf("MkdirTemp: rtmr entry %q cannot have subdirectories", dir)
 	}
-	if _, err := os.Stat(r.Path); os.IsNotExist(err) {
-		if err = os.Mkdir(r.Path, 0755); err != nil {
-			return "", fmt.Errorf("MkdirTemp: %v", err)
-		}
+	if err = os.MkdirAll(r.Path, 0755); err != nil {
+		return "", fmt.Errorf("MkdirTemp: %v", err)
 	}
 	name := configfsi.TempName(r.Random, pattern)
 	fakeRtmrPath := path.Join(r.Path, name)

--- a/configfs/faketsm/fakereport.go
+++ b/configfs/faketsm/fakereport.go
@@ -142,6 +142,11 @@ func (e *ReportEntry) readCached(attr string) ([]byte, error) {
 
 }
 
+// ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
+func (r *ReportSubsystem) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return nil, errors.New("report subsystem does not support ReadDir")
+}
+
 // ReadFile reads the named file and returns the contents.
 func (r *ReportSubsystem) ReadFile(name string) ([]byte, error) {
 	p, err := configfsi.ParseTsmPath(name)

--- a/configfs/faketsm/faketsm.go
+++ b/configfs/faketsm/faketsm.go
@@ -20,6 +20,7 @@ package faketsm
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/google/go-configfs-tsm/configfs/configfsi"
 )
@@ -43,6 +44,18 @@ func (c *Client) getSubsystem(name string) (configfsi.Client, error) {
 		return nil, fmt.Errorf("faketsm: unsupported subsystem %q", p.Subsystem)
 	}
 	return sub, nil
+}
+
+// ReadDir reads the directory named by dir and returns a list of directory entries.
+func (c *Client) ReadDir(dir string) ([]os.DirEntry, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("faketsm doesn't implement empty directory behavior")
+	}
+	sub, err := c.getSubsystem(dir)
+	if err != nil {
+		return nil, err
+	}
+	return sub.ReadDir(dir)
 }
 
 // MkdirTemp creates a new temporary directory in the directory dir and returns the pathname

--- a/configfs/linuxtsm/linuxtsm.go
+++ b/configfs/linuxtsm/linuxtsm.go
@@ -48,6 +48,12 @@ func (*client) RemoveAll(path string) error {
 	return os.Remove(path)
 }
 
+// ReadDir reads the directory named by dirname and returns a list of directory
+// entries sorted by filename.
+func (*client) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return os.ReadDir(dirname)
+}
+
 // MakeClient returns a "real" client for using configfs for TSM use.
 func MakeClient() (configfsi.Client, error) {
 	// Linux client expects just the "report" subsystem for now.

--- a/rtmr/rtmr.go
+++ b/rtmr/rtmr.go
@@ -19,8 +19,6 @@ package rtmr
 import (
 	"crypto"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/google/go-configfs-tsm/configfs/configfsi"
@@ -75,8 +73,11 @@ func (r *Extend) getTcgMap() ([]byte, error) {
 	return r.client.ReadFile(r.attribute(tsmPathTcgMap))
 }
 
-// validateIndex checks if the rtmr index match the expected value.
+// validateIndex checks if the rtmr index matches the expected value.
 func (r *Extend) validateIndex() bool {
+	if r == nil {
+		return false
+	}
 	indexBytes, err := r.client.ReadFile(r.attribute(tsmPathIndex))
 	if err != nil {
 		return false
@@ -105,31 +106,23 @@ func (r *Extend) setRtmrIndex() error {
 // searchRtmrInterface searches for an rtmr entry in the configfs.
 func searchRtmrInterface(client configfsi.Client, index int) *Extend {
 	root := tsmRtmrPrefix
-	out := &Extend{}
-	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() {
-			p, err := configfsi.ParseTsmPath(path)
-			if err != nil {
-				return err
-			}
+	entries, err := client.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	for _, d := range entries {
+		if d.IsDir() {
 			r := &Extend{
 				RtmrIndex: index,
-				entry:     &configfsi.TsmPath{Subsystem: rtmrSubsystem, Entry: p.Entry},
+				entry:     &configfsi.TsmPath{Subsystem: rtmrSubsystem, Entry: d.Name()},
 				client:    client,
 			}
 			if r.validateIndex() {
-				out = r
-				return nil
+				return r
 			}
 		}
-		return nil
-	}); err != nil || !out.validateIndex() {
-		return nil
 	}
-	return out
+	return nil
 }
 
 // createRtmrInterface creates a new rtmr entry in the configfs.

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -52,6 +52,7 @@ func TestExtendDigestRtmrOk(t *testing.T) {
 	}{
 		{rtmr: 2, digest: sha384Hash[:]},
 		{rtmr: 3, digest: sha384Hash[:]},
+		// Test the same rtmr index with an existing entry.
 		{rtmr: 3, digest: sha384Hash[:]},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
@@ -90,6 +91,8 @@ func TestGetDigestOk(t *testing.T) {
 		{rtmr: 1, digest: sha384Hash[:], tcgMap: []byte("2-6\n")},
 		{rtmr: 2, digest: sha384Hash[:], tcgMap: []byte("8-15\n")},
 		{rtmr: 3, digest: sha384Hash[:], tcgMap: []byte("\n")},
+		// Test the same rtmr index with an existing entry.
+		{rtmr: 2, digest: sha384Hash[:], tcgMap: []byte("8-15\n")},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
 	for _, tc := range tcsOk {

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -100,9 +100,6 @@ func TestGetDigestOk(t *testing.T) {
 		if r.RtmrIndex != tc.rtmr {
 			t.Fatalf("GetDigestRtmr(%d) failed: got %d, want %d", tc.rtmr, r.RtmrIndex, tc.rtmr)
 		}
-		if !bytes.Equal(r.digest, tc.digest) {
-			t.Fatalf("GetDigestRtmr(%d) failed: got %q, want %q", tc.rtmr, r.digest, tc.digest)
-		}
 		if !bytes.Equal(r.tcgMap, tc.tcgMap) {
 			t.Fatalf("GetDigestRtmr(%d) failed: got %q, want %q", tc.rtmr, r.tcgMap, tc.tcgMap)
 		}


### PR DESCRIPTION
It is hard to write an in-memory fake rtmr subsystem. I decided to use a temp folder to store the rtmr values. 

1. Use the temp filesystem to mock the fake rtmt subsystem

2. fix a nil dereference bug in validateIndex
The bug should be covered by the previous test case. However, due to the limitation of the previous fake rtmr subsystem, the bug was not caught. The new fake rtmr subsystem covers the case.

The PR has been tested on the real TDX machine and all the unit tests pass now.
golangci-lint run passes as well.

