### PR TITLE
Clear the temporary files for the fake rtmrSubsystem.

### DIFF
--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -193,13 +193,19 @@ func (r *RtmrSubsystem) WriteFile(name string, content []byte) error {
 	return r.WriteAttr(path.Join(r.Path, p.Entry), p.Attribute, content, r.rtmrIndexMap)
 }
 
+// Close removes the temporary files in the fake rtmr subsystem.
+func (r *RtmrSubsystem) Close() error {
+	return os.RemoveAll(r.Path)
+}
+
 // CreateRtmrSubsystem creates a new rtmr subsystem.
 // The current subsystem only supports TDX.
 func CreateRtmrSubsystem() *RtmrSubsystem {
 	return &RtmrSubsystem{
-		Random:    rand.Reader,
-		WriteAttr: writeTdx,
-		ReadAttr:  readTdx,
-		Path:      path.Join(os.TempDir(), tsmRtmrSubsystem),
+		Random:       rand.Reader,
+		WriteAttr:    writeTdx,
+		ReadAttr:     readTdx,
+		Path:         path.Join(os.TempDir(), tsmRtmrSubsystem),
+		rtmrIndexMap: make(map[int]bool),
 	}
 }

--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -64,68 +64,71 @@ func readTdx(entry string, attr string) ([]byte, error) {
 	return os.ReadFile(path.Join(entry, attr))
 }
 
-func writeTdx(entry string, attr string, content []byte, indexMap map[int]bool) error {
-	switch attr {
-	case tsmRtmrDigest:
-		// Check if the content is a valid SHA384 hash.
-		if len(content) != crypto.SHA384.Size() {
-			return syscall.EINVAL
-		}
-		// Check if the entry is initialized.
-		content, err := os.ReadFile(filepath.Join(entry, tsmPathIndex))
-		if err != nil {
-			return err
-		}
-		rtmrIndex, err := strconv.Atoi(string(content))
-		if err != nil {
-			return err
-		}
-		if rtmrIndex != 2 && rtmrIndex != 3 {
-			return os.ErrPermission
-		}
-		oldDigest, err := os.ReadFile(filepath.Join(entry, tsmRtmrDigest))
-		if err != nil {
-			return err
-		}
-		newDigest := sha512.Sum384(append(oldDigest[:], content...))
-		if err := os.WriteFile(filepath.Join(entry, tsmRtmrDigest), newDigest[:], 0666); err != nil {
-			return err
-		}
-	case tsmPathIndex:
-		rtmrIndex, e := strconv.Atoi(string(content))
-		if e != nil {
-			return fmt.Errorf("WriteTdx: %v", e)
-		}
-		if rtmrIndex < 0 || rtmrIndex > 3 {
-			return fmt.Errorf("WriteTdx: invalid rtmr index %d. Index can only be a non-negative number", rtmrIndex)
-		}
-		if indexMap[rtmrIndex] {
-			return syscall.EBUSY
-		}
-		indexMap[rtmrIndex] = true
-		if err := os.WriteFile(filepath.Join(entry, tsmPathIndex), content, 0666); err != nil {
-			return err
-		}
-		var rtmrPcrMaps = map[int]string{
-			0: "1,7\n",
-			1: "2-6\n",
-			2: "8-15\n",
-			3: "\n",
-		}
-		tempTsmPathTcgMap := filepath.Join(os.TempDir(), tsmPathTcgMap)
-		if err := os.WriteFile(tempTsmPathTcgMap, []byte(rtmrPcrMaps[rtmrIndex]), 0400); err != nil {
-			return err
-		}
-		if err := os.Rename(tempTsmPathTcgMap, filepath.Join(entry, tsmPathTcgMap)); err != nil {
-			return err
-		}
+func makeWriteTdx(root string) func(entry string, attr string, content []byte, indexMap map[int]bool) error {
+	return func(entry string, attr string, content []byte, indexMap map[int]bool) error {
+		switch attr {
+		case tsmRtmrDigest:
+			// Check if the content is a valid SHA384 hash.
+			if len(content) != crypto.SHA384.Size() {
+				return syscall.EINVAL
+			}
+			// Check if the entry is initialized.
+			content, err := os.ReadFile(filepath.Join(entry, tsmPathIndex))
+			if err != nil {
+				return err
+			}
+			rtmrIndex, err := strconv.Atoi(string(content))
+			if err != nil {
+				return err
+			}
+			if rtmrIndex != 2 && rtmrIndex != 3 {
+				return os.ErrPermission
+			}
+			oldDigest, err := os.ReadFile(filepath.Join(entry, tsmRtmrDigest))
+			if err != nil {
+				return err
+			}
+			newDigest := sha512.Sum384(append(oldDigest[:], content...))
+			if err := os.WriteFile(filepath.Join(entry, tsmRtmrDigest), newDigest[:], 0666); err != nil {
+				return err
+			}
+		case tsmPathIndex:
+			rtmrIndex, e := strconv.Atoi(string(content))
+			if e != nil {
+				return fmt.Errorf("WriteTdx: %v", e)
+			}
+			if rtmrIndex < 0 || rtmrIndex > 3 {
+				return fmt.Errorf("WriteTdx: invalid rtmr index %d. Index can only be a non-negative number", rtmrIndex)
+			}
+			if indexMap[rtmrIndex] {
+				return syscall.EBUSY
+			}
+			indexMap[rtmrIndex] = true
+			if err := os.WriteFile(filepath.Join(entry, tsmPathIndex), content, 0666); err != nil {
+				return err
+			}
+			var rtmrPcrMaps = map[int]string{
+				0: "1,7\n",
+				1: "2-6\n",
+				2: "8-15\n",
+				3: "\n",
+			}
+			// Write the tcgmap into a temp file and rename it to keep the read-only permission.
+			tempTsmPathTcgMap := filepath.Join(root, tsmPathTcgMap)
+			if err := os.WriteFile(tempTsmPathTcgMap, []byte(rtmrPcrMaps[rtmrIndex]), 0400); err != nil {
+				return err
+			}
+			if err := os.Rename(tempTsmPathTcgMap, filepath.Join(entry, tsmPathTcgMap)); err != nil {
+				return err
+			}
 
-	case tsmPathTcgMap:
-		return os.ErrPermission
-	default:
-		return fmt.Errorf("WriteTdx: unknown attribute %q", attr)
+		case tsmPathTcgMap:
+			return os.ErrPermission
+		default:
+			return fmt.Errorf("WriteTdx: unknown attribute %q", attr)
+		}
+		return nil
 	}
-	return nil
 }
 
 // ReadDir reads the directory named by dirname
@@ -198,7 +201,7 @@ func (r *RtmrSubsystem) WriteFile(name string, content []byte) error {
 func CreateRtmrSubsystem(tempDir string) *RtmrSubsystem {
 	return &RtmrSubsystem{
 		Random:       rand.Reader,
-		WriteAttr:    writeTdx,
+		WriteAttr:    makeWriteTdx(tempDir),
 		ReadAttr:     readTdx,
 		Path:         path.Join(tempDir, tsmRtmrSubsystem),
 		rtmrIndexMap: make(map[int]bool),

--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -112,7 +112,7 @@ func writeTdx(entry string, attr string, content []byte, indexMap map[int]bool) 
 			2: "8-15\n",
 			3: "\n",
 		}
-		tempTsmPathTcgMap := filepath.Join(os.TempDir(), tsmRtmrSubsystem, tsmPathTcgMap)
+		tempTsmPathTcgMap := filepath.Join(os.TempDir(), tsmPathTcgMap)
 		if err := os.WriteFile(tempTsmPathTcgMap, []byte(rtmrPcrMaps[rtmrIndex]), 0400); err != nil {
 			return err
 		}
@@ -193,19 +193,14 @@ func (r *RtmrSubsystem) WriteFile(name string, content []byte) error {
 	return r.WriteAttr(path.Join(r.Path, p.Entry), p.Attribute, content, r.rtmrIndexMap)
 }
 
-// Close removes the temporary files in the fake rtmr subsystem.
-func (r *RtmrSubsystem) Close() error {
-	return os.RemoveAll(r.Path)
-}
-
 // CreateRtmrSubsystem creates a new rtmr subsystem.
 // The current subsystem only supports TDX.
-func CreateRtmrSubsystem() *RtmrSubsystem {
+func CreateRtmrSubsystem(tempDir string) *RtmrSubsystem {
 	return &RtmrSubsystem{
 		Random:       rand.Reader,
 		WriteAttr:    writeTdx,
 		ReadAttr:     readTdx,
-		Path:         path.Join(os.TempDir(), tsmRtmrSubsystem),
+		Path:         path.Join(tempDir, tsmRtmrSubsystem),
 		rtmrIndexMap: make(map[int]bool),
 	}
 }

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -35,6 +35,7 @@ func TestExtendDigestErr(t *testing.T) {
 		{rtmr: -1, digest: sha384Hash[:], wantErr: "invalid rtmr index -1. Index can only be a non-negative number"},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
+	defer client.Close()
 	for _, tc := range tcsErr {
 		err := ExtendDigest(client, tc.rtmr, tc.digest)
 		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -56,6 +57,7 @@ func TestExtendDigestRtmrOk(t *testing.T) {
 		{rtmr: 3, digest: sha384Hash[:]},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
+	defer client.Close()
 	for _, tc := range tcsOk {
 		err := ExtendDigest(client, tc.rtmr, tc.digest)
 		if err != nil {
@@ -72,6 +74,7 @@ func TestGetDigestErr(t *testing.T) {
 		{rtmr: -1, wantErr: "invalid rtmr index -1. Index can only be a non-negative number"},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
+	defer client.Close()
 	for _, tc := range tcsErr {
 		_, err := GetDigest(client, tc.rtmr)
 		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -95,6 +98,7 @@ func TestGetDigestOk(t *testing.T) {
 		{rtmr: 2, digest: sha384Hash[:], tcgMap: []byte("8-15\n")},
 	}
 	client := fakertmr.CreateRtmrSubsystem()
+	defer client.Close()
 	for _, tc := range tcsOk {
 		r, err := GetDigest(client, tc.rtmr)
 		if err != nil {
@@ -113,6 +117,7 @@ func TestGetRtmrDigestAndExtendDigest(t *testing.T) {
 	var sha384Hash [48]byte
 	sha384Hash[0] = 0x01
 	client := fakertmr.CreateRtmrSubsystem()
+	defer client.Close()
 	rtmrIndex := 3
 	// GetDigest
 	digest1, err := GetDigest(client, rtmrIndex)

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -34,8 +34,7 @@ func TestExtendDigestErr(t *testing.T) {
 		{rtmr: 3, digest: []byte("aaaaaaaa"), wantErr: "the length of the digest must be 48 bytes"},
 		{rtmr: -1, digest: sha384Hash[:], wantErr: "invalid rtmr index -1. Index can only be a non-negative number"},
 	}
-	client := fakertmr.CreateRtmrSubsystem()
-	defer client.Close()
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
 	for _, tc := range tcsErr {
 		err := ExtendDigest(client, tc.rtmr, tc.digest)
 		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -56,8 +55,7 @@ func TestExtendDigestRtmrOk(t *testing.T) {
 		// Test the same rtmr index with an existing entry.
 		{rtmr: 3, digest: sha384Hash[:]},
 	}
-	client := fakertmr.CreateRtmrSubsystem()
-	defer client.Close()
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
 	for _, tc := range tcsOk {
 		err := ExtendDigest(client, tc.rtmr, tc.digest)
 		if err != nil {
@@ -73,8 +71,7 @@ func TestGetDigestErr(t *testing.T) {
 	}{
 		{rtmr: -1, wantErr: "invalid rtmr index -1. Index can only be a non-negative number"},
 	}
-	client := fakertmr.CreateRtmrSubsystem()
-	defer client.Close()
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
 	for _, tc := range tcsErr {
 		_, err := GetDigest(client, tc.rtmr)
 		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -97,8 +94,7 @@ func TestGetDigestOk(t *testing.T) {
 		// Test the same rtmr index with an existing entry.
 		{rtmr: 2, digest: sha384Hash[:], tcgMap: []byte("8-15\n")},
 	}
-	client := fakertmr.CreateRtmrSubsystem()
-	defer client.Close()
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
 	for _, tc := range tcsOk {
 		r, err := GetDigest(client, tc.rtmr)
 		if err != nil {
@@ -116,8 +112,7 @@ func TestGetDigestOk(t *testing.T) {
 func TestGetRtmrDigestAndExtendDigest(t *testing.T) {
 	var sha384Hash [48]byte
 	sha384Hash[0] = 0x01
-	client := fakertmr.CreateRtmrSubsystem()
-	defer client.Close()
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
 	rtmrIndex := 3
 	// GetDigest
 	digest1, err := GetDigest(client, rtmrIndex)


### PR DESCRIPTION
`rtmrIndexMap` is added to track that one rtmr index only has one entry.

The fake rtmr subsystem has a nil deference issue in `rtmrIndexMap`. The bug was not discovered because the  tempory files are not cleared after the test. This PR clears the temporary files for the fake rtmrSubsystem and fixs the nil deference issue.