### PR TITLE
Export Digest and TcgMap fields in rtmr.Response

### DIFF
--- a/rtmr/rtmr.go
+++ b/rtmr/rtmr.go
@@ -45,8 +45,8 @@ type Extend struct {
 // Response is a struct that represents the response of reading a rtmr entry in the configfs.
 type Response struct {
 	RtmrIndex int
-	digest    []byte
-	tcgMap    []byte
+	Digest    []byte
+	TcgMap    []byte
 }
 
 func (r *Extend) attribute(subtree string) string {
@@ -192,7 +192,7 @@ func GetDigest(client configfsi.Client, rtmr int) (*Response, error) {
 
 	return &Response{
 		RtmrIndex: rtmr,
-		digest:    digest,
-		tcgMap:    tcgmap,
+		Digest:    digest,
+		TcgMap:    tcgmap,
 	}, nil
 }

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -103,8 +103,8 @@ func TestGetDigestOk(t *testing.T) {
 		if r.RtmrIndex != tc.rtmr {
 			t.Fatalf("GetDigestRtmr(%d) failed: got %d, want %d", tc.rtmr, r.RtmrIndex, tc.rtmr)
 		}
-		if !bytes.Equal(r.tcgMap, tc.tcgMap) {
-			t.Fatalf("GetDigestRtmr(%d) failed: got %q, want %q", tc.rtmr, r.tcgMap, tc.tcgMap)
+		if !bytes.Equal(r.TcgMap, tc.tcgMap) {
+			t.Fatalf("GetDigestRtmr(%d) failed: got %q, want %q", tc.rtmr, r.TcgMap, tc.tcgMap)
 		}
 	}
 }
@@ -129,7 +129,7 @@ func TestGetRtmrDigestAndExtendDigest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDigest(%d) failed: %v", rtmrIndex, err)
 	}
-	if bytes.Equal(digest1.digest, digest2.digest) {
-		t.Fatalf("rtmr%q does not change after an extend %q", rtmrIndex, digest2.digest)
+	if bytes.Equal(digest1.Digest, digest2.Digest) {
+		t.Fatalf("rtmr%q does not change after an extend %q", rtmrIndex, digest2.Digest)
 	}
 }


### PR DESCRIPTION
This will be helpful for testing/replaying eventlog using `fakertmr`. For now I can extend to the `fakertmr`, but cannot get the value of the RTMR (because it's unexported).