### PR TITLE
Fix the rtmr calculation error in fakertmr.

### DIFF
--- a/configfs/fakertmr/fakertmr.go
+++ b/configfs/fakertmr/fakertmr.go
@@ -73,11 +73,11 @@ func makeWriteTdx(root string) func(entry string, attr string, content []byte, i
 				return syscall.EINVAL
 			}
 			// Check if the entry is initialized.
-			content, err := os.ReadFile(filepath.Join(entry, tsmPathIndex))
+			indexFile, err := os.ReadFile(filepath.Join(entry, tsmPathIndex))
 			if err != nil {
 				return err
 			}
-			rtmrIndex, err := strconv.Atoi(string(content))
+			rtmrIndex, err := strconv.Atoi(string(indexFile))
 			if err != nil {
 				return err
 			}
@@ -119,6 +119,13 @@ func makeWriteTdx(root string) func(entry string, attr string, content []byte, i
 				return err
 			}
 			if err := os.Rename(tempTsmPathTcgMap, filepath.Join(entry, tsmPathTcgMap)); err != nil {
+				return err
+			}
+			// Initialize the digest file to all zeros.
+			// SHA-384 produces a 48-byte hash.
+			const sha384Size = 48
+			digest := [sha384Size]byte{}
+			if err := os.WriteFile(filepath.Join(entry, tsmRtmrDigest), digest[:], 0666); err != nil {
 				return err
 			}
 

--- a/rtmr/rtmr_test.go
+++ b/rtmr/rtmr_test.go
@@ -114,10 +114,15 @@ func TestGetRtmrDigestAndExtendDigest(t *testing.T) {
 	sha384Hash[0] = 0x01
 	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
 	rtmrIndex := 3
+	initRtmrValue := []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	extendRtmrValue := []byte("ܮ\x87\xd5n\xa6\x12\x15\xf3#\xa6&0`\xb6\x96(\x02\xb2Po\x80\xbe*\x92\xcb\fJ\x1f\x06\x80\xf0\x9c\x14\xee\xaan\x82\xc9\xfa\x9a\xec\xf9ROeś")
 	// GetDigest
 	digest1, err := GetDigest(client, rtmrIndex)
 	if err != nil {
 		t.Fatalf("GetDigest(%d) failed: %v", rtmrIndex, err)
+	}
+	if !bytes.Equal(digest1.Digest, initRtmrValue) {
+		t.Fatalf("rtmr%q does not have the all-zero initial value %q", rtmrIndex, digest1.Digest)
 	}
 	// ExtendDigest
 	err = ExtendDigest(client, rtmrIndex, sha384Hash[:])
@@ -129,7 +134,7 @@ func TestGetRtmrDigestAndExtendDigest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDigest(%d) failed: %v", rtmrIndex, err)
 	}
-	if bytes.Equal(digest1.Digest, digest2.Digest) {
-		t.Fatalf("rtmr%q does not change after an extend %q", rtmrIndex, digest2.Digest)
+	if !bytes.Equal(digest2.Digest, extendRtmrValue) {
+		t.Fatalf("rtmr%q does not match the expected value: got %q, want %q", rtmrIndex, digest2.Digest, extendRtmrValue)
 	}
 }


### PR DESCRIPTION
Jiankun notices that the digest value in the fakertmr is different from the actual RTMR value after an extend operation. It turns out to be bugs in the implementation.

This PR makes the following change.
1.  Initializes the fake RTMR bank to all zero. Currently, it is an empty slice.
2.  Use `indexFile` to store the rtmr index so the code does not mess up with the `content`.





